### PR TITLE
Add test for ToString not missing the first line

### DIFF
--- a/tests/TestsToString.elm
+++ b/tests/TestsToString.elm
@@ -1,0 +1,40 @@
+module TestsToString exposing (toStringTests)
+
+import Diff
+import Diff.ToString
+import Expect
+import Test exposing (Test, describe, test)
+
+
+toStringTests : Test
+toStringTests =
+    describe "Diff.ToString"
+        [ test "includes first unchanged line before a change" <|
+            \() ->
+                let
+                    fst =
+                        List.range 1 9
+                            |> List.map String.fromInt
+                            |> String.join "\n"
+
+                    snd =
+                        List.range 1 9
+                            |> List.filter (\x -> x /= 6)
+                            |> List.map String.fromInt
+                            |> String.join "\n"
+
+                    result =
+                        Diff.diffLinesWith
+                            (Diff.defaultOptions
+                                |> Diff.ignoreLeadingWhitespace
+                            )
+                            fst
+                            snd
+                            |> Diff.ToString.diffToString { context = 10000, color = False }
+                in
+                Expect.all
+                    [ String.startsWith " 1\n" >> Expect.equal True
+                    , String.contains "-6\n" >> Expect.equal True
+                    ]
+                    result
+        ]


### PR DESCRIPTION
Related to #2. Without the code in there, this test fails with:

<img width="798" height="344" alt="Screenshot 2026-06-14 at 10 25 55" src="https://github.com/user-attachments/assets/71159886-5006-4757-aad0-7effd26b22b5" />
